### PR TITLE
Fixed a statement using raw data instead of preprocessed data.

### DIFF
--- a/irc.py
+++ b/irc.py
@@ -110,7 +110,7 @@ while True:
     for ircmsg in process_data(data):
         if "PING :" in ircmsg:
             ircsock.send("PONG :ping\n")
-        elif channel in data:
+        elif channel in ircmsg:
             args = parsemsg(ircmsg)
             cmd = get_command(args["command"])
             try:


### PR DESCRIPTION
`data` is the raw data received from the socket. If the data sent by the IRC server does not fit in the buffer only a partial message will be received. Furthermore there is no guarantee that the data received from the socket contains a single message. That is why the `process_data` function is used.